### PR TITLE
Port to 1.16.5

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,6 @@
   "depends":{
     "fabricloader":">=0.10.8",
     "fabric":"*",
-    "minecraft":"1.16.4"
+    "minecraft":"1.16.x"
   }
 }


### PR DESCRIPTION
Updates the fabric.mod.json to support Minecraft 1.16.5, as there were zero breaking changes between 1.16.4 and it.